### PR TITLE
Add option for automatic creation of non-existent torrent directories

### DIFF
--- a/lib/Commands/DownloadReleaseInfoCommand.js
+++ b/lib/Commands/DownloadReleaseInfoCommand.js
@@ -104,6 +104,18 @@ class DownloadReleaseInfoCommand extends Command {
 
                   Logger.info(`Finding release information for ${albumArtistInfo} (edition ${edition}) (directory: ${directoryName})...`);
 
+                  if (options.create) {
+                    try {
+                      if (!fs.existsSync(`${seedDir}${directoryName}`)){
+                        fs.mkdirSync(`${seedDir}${directoryName}`);
+                      }
+                      Logger.warn(`Torrent directory ${seedDir}${directoryName} did not exist. Creating.`);
+                    } catch (e) {
+                      Logger.error(`Couldn't create directory ${seedDir}${directoryName}`);
+                      return callback();
+                    }
+                  }
+
                   try {
                     fs.statSync(`${seedDir}${directoryName}`);
                   } catch(e) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,7 +94,7 @@ let cliConfig = {
         'create': {
           group: 'Flags:',
           demand: false,
-          desc: 'Create torrent directory if it does not already exist',
+          desc: 'Create non-existent torrent directories',
           type: 'boolean',
         },
       },

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -91,6 +91,12 @@ let cliConfig = {
           desc: 'Force writing release info file if it already exists',
           type: 'boolean',
         },
+        'create': {
+          group: 'Flags:',
+          demand: false,
+          desc: 'Create torrent directory if it does not already exist',
+          type: 'boolean',
+        },
       },
       file: './Commands/DownloadReleaseInfoCommand',
     },


### PR DESCRIPTION
Added "--create" flag to options list for download-release-info.